### PR TITLE
Changed displayed status and translations

### DIFF
--- a/custom_components/remeha_home/climate.py
+++ b/custom_components/remeha_home/climate.py
@@ -42,15 +42,15 @@ REMEHA_STATUS_TO_HVAC_ACTION = {
 }
 
 PRESET_INDEX_TO_PRESET_MODE = {
-    1: "Schedule 1",
-    2: "Schedule 2",
-    3: "Schedule 3",
+    1: "schedule_1",
+    2: "schedule_2",
+    3: "schedule_3",
 }
 
 PRESET_MODE_TO_PRESET_INDEX = {
-    "Schedule 1": 1,
-    "Schedule 2": 2,
-    "Schedule 3": 3,
+    "schedule_1": 1,
+    "schedule_2": 2,
+    "schedule_3": 3,
 }
 
 async def async_setup_entry(

--- a/custom_components/remeha_home/climate.py
+++ b/custom_components/remeha_home/climate.py
@@ -42,15 +42,15 @@ REMEHA_STATUS_TO_HVAC_ACTION = {
 }
 
 PRESET_INDEX_TO_PRESET_MODE = {
-    1: "schedule_1",
-    2: "schedule_2",
-    3: "schedule_3",
+    1: "clock_program_1",
+    2: "clock_program_2",
+    3: "clock_program_3",
 }
 
 PRESET_MODE_TO_PRESET_INDEX = {
-    "schedule_1": 1,
-    "schedule_2": 2,
-    "schedule_3": 3,
+    "clock_program_1": 1,
+    "clock_program_2": 2,
+    "clock_program_3": 3,
 }
 
 async def async_setup_entry(
@@ -151,9 +151,9 @@ class RemehaHomeClimateEntity(CoordinatorEntity, ClimateEntity):
     def preset_mode(self) -> str | None:
         """Return the preset mode."""
         if self.hvac_mode == HVACMode.OFF:
-            return "Frost protection"
+            return "anti_frost"
         if self.hvac_mode == HVACMode.HEAT:
-            return "Manual"
+            return "manual"
         return PRESET_INDEX_TO_PRESET_MODE[
             self._data["activeHeatingClimateTimeProgramNumber"]
         ]

--- a/custom_components/remeha_home/climate.py
+++ b/custom_components/remeha_home/climate.py
@@ -53,6 +53,7 @@ PRESET_MODE_TO_PRESET_INDEX = {
     "clock_program_3": 3,
 }
 
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,

--- a/custom_components/remeha_home/climate.py
+++ b/custom_components/remeha_home/climate.py
@@ -42,17 +42,16 @@ REMEHA_STATUS_TO_HVAC_ACTION = {
 }
 
 PRESET_INDEX_TO_PRESET_MODE = {
-    1: "clock_program_1",
-    2: "clock_program_2",
-    3: "clock_program_3",
+    1: "Schedule 1",
+    2: "Schedule 2",
+    3: "Schedule 3",
 }
 
 PRESET_MODE_TO_PRESET_INDEX = {
-    "clock_program_1": 1,
-    "clock_program_2": 2,
-    "clock_program_3": 3,
+    "Schedule 1": 1,
+    "Schedule 2": 2,
+    "Schedule 3": 3,
 }
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -151,6 +150,10 @@ class RemehaHomeClimateEntity(CoordinatorEntity, ClimateEntity):
     @property
     def preset_mode(self) -> str | None:
         """Return the preset mode."""
+        if self.hvac_mode == HVACMode.OFF:
+            return "Frost protection"
+        if self.hvac_mode == HVACMode.HEAT:
+            return "Manual"
         return PRESET_INDEX_TO_PRESET_MODE[
             self._data["activeHeatingClimateTimeProgramNumber"]
         ]

--- a/custom_components/remeha_home/translations/en.json
+++ b/custom_components/remeha_home/translations/en.json
@@ -21,9 +21,11 @@
                 "state_attributes": {
                     "preset_mode": {
                         "state": {
-                            "clock_program_1": "Clock program 1",
-                            "clock_program_2": "Clock program 2",
-                            "clock_program_3": "Clock program 3"
+                            "clock_program_1": "Schedule 1",
+                            "clock_program_2": "Schedule 2",
+                            "clock_program_3": "Schedule 3",
+                            "anti_frost": "Frost protection",
+                            "manual": "Manual"
                         }
                     }
                 }

--- a/custom_components/remeha_home/translations/fr.json
+++ b/custom_components/remeha_home/translations/fr.json
@@ -1,0 +1,35 @@
+{
+    "config": {
+        "abort": {
+            "failed_to_authenticate": "Authentification interrompue"
+        },
+        "error": {
+            "failed_to_authenticate": "Adresse email ou mot de passe invalide"
+        },
+        "step": {
+            "auth": {
+                "data": {
+                    "email": "Addresse e-mail",
+                    "password": "Mot de passe"
+                }
+            }
+        }
+    },
+    "entity": {
+        "climate": {
+            "remeha_home": {
+                "state_attributes": {
+                    "preset_mode": {
+                        "state": {
+                            "clock_program_1": "Programme 1",
+                            "clock_program_2": "Programme 2",
+                            "clock_program_3": "Programme 3",
+                            "anti_frost": "Hors-gel",
+                            "manual": "Manuel"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/custom_components/remeha_home/translations/nl.json
+++ b/custom_components/remeha_home/translations/nl.json
@@ -23,7 +23,9 @@
                         "state": {
                             "clock_program_1": "Klokprogramma 1",
                             "clock_program_2": "Klokprogramma 2",
-                            "clock_program_3": "Klokprogramma 3"
+                            "clock_program_3": "Klokprogramma 3",
+                            "anti_frost": "Vorst bescherming",
+                            "manual": "Handmatig"
                         }
                     }
                 }


### PR DESCRIPTION
Hi Michiel,

Your code is very neat and clean, congrats, and I'd like to propose the following small changes, only aesthetics, after I compared your integration with the app and my expectations from my previous home-made version of this integration.

I can propose 3 changes:

1/ the "preset" text is showing the translated text for "anti_frost" when the hvac mode is "off", and the translated text for "manual" when the hvac mode is "heat". I added the translation for it in each language file.

2/ the English translation for the schedule presets is changed to "Schedule X" (could also be "Heating X" to stick closer to the app if you would prefer)

3/ I added a new translation file in French :)

Hope you like it! I tested it on my HA instance and it seems to work fine.