### PR TITLE
Fix explicit device naming

### DIFF
--- a/custom_components/remeha_home/climate.py
+++ b/custom_components/remeha_home/climate.py
@@ -81,6 +81,7 @@ class RemehaHomeClimateEntity(CoordinatorEntity, ClimateEntity):
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_precision = PRECISION_HALVES
     _attr_has_entity_name = True
+    _attr_name = None
     _attr_translation_key = "remeha_home"
 
     def __init__(


### PR DESCRIPTION
Resolves below warning introduced in 2023.7.0b0

`
2023-07-02 08:16:06.333 WARNING (MainThread) [homeassistant.helpers.entity] Entity None (<class 'custom_components.remeha_home.climate.RemehaHomeClimateEntity'>) is implicitly using device name by not setting its name. Instead, the name should be set to None, please report it to the custom integration author.`