### PR TITLE
Add TURN_ON/OFF ClimateEntityFeature for remeha_home

### DIFF
--- a/custom_components/remeha_home/climate.py
+++ b/custom_components/remeha_home/climate.py
@@ -75,8 +75,12 @@ async def async_setup_entry(
 class RemehaHomeClimateEntity(CoordinatorEntity, ClimateEntity):
     """Climate entity representing a Remeha Home climate zone."""
 
+    _enable_turn_on_off_backwards_compatibility = False
     _attr_supported_features = (
-        ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.PRESET_MODE
+        | ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.TURN_ON
     )
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_precision = PRECISION_HALVES


### PR DESCRIPTION
2024.2.0b0 is generating below warning hence implementing as per [developer blog](https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded/)

`2024-02-01 10:17:56.823 WARNING (MainThread) [homeassistant.components.climate] Entity None (<class 'custom_components.remeha_home.climate.RemehaHomeClimateEntity'>) implements HVACMode(s): off, heat, auto and therefore implicitly supports the turn_on/turn_off methods without setting the proper ClimateEntityFeature. Please create a bug report at https://github.com/msvisser/remeha_home/issues`

