### PR TITLE
Fix stale data after controlling the temperature or another setting

### DIFF
--- a/custom_components/remeha_home/api.py
+++ b/custom_components/remeha_home/api.py
@@ -34,7 +34,6 @@ class RemehaHomeAPI:
 
     async def async_get_access_token(self) -> str:
         """Return a valid access token."""
-        _LOGGER.warning("GOT HERE")
         if not self._oauth_session.valid_token:
             await self._oauth_session.async_ensure_token_valid()
 
@@ -54,7 +53,9 @@ class RemehaHomeAPI:
 
     async def async_get_dashboard(self) -> dict:
         """Return the Remeha Home dashboard JSON."""
-        response = await self._async_api_request("GET", "/homes/dashboard")
+        # Add a timestamp to the request to prevent caching
+        timestamp = int(datetime.datetime.now().timestamp())
+        response = await self._async_api_request("GET", f"/homes/dashboard?t={timestamp}")
         response.raise_for_status()
         return await response.json()
 


### PR DESCRIPTION
I've noticed that the integration didn't correctly update after changing values like the temperature or enabling/disabling the fireplace mode. It seems that this is due to some aggressive caching happening on the backend when requesting the `/homes/dashboard` endpoint.

When I added logging, I could see that the API reply didn't contain the changes after changing the temperature for example.

Example log:
```
2024-11-21 17:09:31.868 DEBUG (MainThread) [custom_components.remeha_home.switch] Enable fireplace mode
2024-11-21 17:09:32.026 DEBUG (MainThread) [custom_components.remeha_home.api] Received data from API: {'appliances': [{'applianceId': 'fc00ce82-b915-4f17-bd8b-cfe393ba1eea', 'applianceOnline': True, 'applianceConnectionStatus': 'Connected', 'applianceType': 'GatewayDevice_BSB', 'pairingStatus': 'Paired', 'houseName': 'Thuis', 'errorStatus': 'Running', 'activeThermalMode': 'Idle', 'operatingMode': 'AutomaticHeating', 'outdoorTemperature': 3.5, 'outdoorTemperatureSource': 'Unknown', 'outdoorTemperatureInformation': {'outdoorTemperatureSource': 'Unknown', 'internetOutdoorTemperature': None, 'applianceOutdoorTemperature': 3.5, 'utilizeOutdoorTemperature': None, 'internetOutdoorTemperatureExpected': False, 'isDayTime': True, 'weatherCode': 'partly cloudy', 'cloudOutdoorTemperature': 1, 'cloudOutdoorTemperatureStatus': 'Ok'}, 'currentTimestamp': None, 'holidaySchedule': {'startTime': '0001-01-01T00:00:00Z', 'endTime': '0001-01-01T00:00:00Z', 'active': False}, 'autoFillingMode': 'NotAvailable', 'autoFilling': {'mode': 'NotAvailable', 'status': 'NotAvailable'}, 'waterPressure': 2.2, 'waterPressureOK': True, 'capabilityEnergyConsumption': True, 'capabilityCooling': False, 'capabilityPreHeat': True, 'capabilityMultiSchedule': True, 'capabilityPowerSettings': False, 'capabilityOutdoorTemperature': True, 'capabilityUtilizeOutdoorTemperature': False, 'capabilityInternetOutdoorTemperatureExpected': False, 'hasOverwrittenActivityNames': True, 'gasCalorificValue': 10.6291, 'isActive': True, 'hotWaterZones': [{'hotWaterZoneId': 'b36ee8c2-7978-4589-fade-08dc3db9e92f', 'applianceId': 'fc00ce82-b915-4f17-bd8b-cfe393ba1eea', 'name': 'DHW', 'zoneType': 'DHW', 'dhwZoneMode': 'Scheduling', 'dhwStatus': 'Idle', 'dhwType': 'Tank', 'nextSwitchActivity': 'Reduced', 'capabilityBoostMode': False, 'dhwTemperature': 59.0, 'targetSetpoint': 60.0, 'reducedSetpoint': 45.0, 'comfortSetPoint': 60.0, 'setPointMin': 8.0, 'setPointMax': 65.0, 'setPointRanges': {'comfortSetpointMin': 8.0, 'comfortSetpointMax': 65.0, 'reducedSetpointMin': 8.0, 'reducedSetpointMax': 65.0}, 'boostDuration': None, 'boostModeEndTime': None, 'nextSwitchTime': '2024-11-21T22:00:00Z', 'activeDwhTimeProgramNumber': 1}], 'climateZones': [{'climateZoneId': 'b4700384-113a-4b1b-672f-08dc3db9e92f', 'applianceId': 'fc00ce82-b915-4f17-bd8b-cfe393ba1eea', 'name': 'Woonkamer', 'zoneIcon': 0, 'zoneType': 'CH', 'activeComfortDemand': 'Idle', 'zoneMode': 'TemporaryOverride', 'controlStrategy': 'RoomTemperatureOnly', 'firePlaceModeActive': False, 'capabilityFirePlaceMode': True, 'roomTemperature': 23.0, 'setPoint': 20.0, 'nextSetpoint': 18.0, 'nextSwitchTime': '2024-11-21T22:00:00Z', 'setPointMin': 4.0, 'setPointMax': 35.0, 'currentScheduleSetPoint': 20.0, 'activeHeatingClimateTimeProgramNumber': 1, 'capabilityCooling': False, 'capabilityTemporaryOverrideEndTime': True, 'preHeat': {'enabled': False, 'active': False}, 'temporaryOverride': {'endTime': '2024-11-21T22:00:00Z'}}], 'solarThermals': []}]}
2024-11-21 17:09:32.027 DEBUG (MainThread) [custom_components.remeha_home.coordinator] Finished fetching remeha_home data in 0.036 seconds (success: True)
```

You could see that firePlaceModeActive is still set to False, after making the call to enable it.

I've solved this by adding a timestamp as query parameter to the URL. This is ignored by the backend, but this way, it returns a fresh copy of the data.