### PR TITLE
use outdoorTemperatureInformation for displaying outdoor temo

### DIFF
--- a/custom_components/remeha_home/const.py
+++ b/custom_components/remeha_home/const.py
@@ -22,7 +22,7 @@ APPLIANCE_SENSOR_TYPES = [
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
-        key="outdoorTemperature",
+        key="outdoorTemperatureInformation.applianceOutdoorTemperature",
         name="Outdoor Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -104,7 +104,6 @@ Response:
       ],
       "houseName": "Home",
       "operatingMode": "AutomaticHeating",
-      "outdoorTemperature": null,
       "outdoorTemperatureInformation": {
         "applianceOutdoorTemperature": null,
         "cloudOutdoorTemperature": 2,


### PR DESCRIPTION
Fix for #87 
Noticed that outdoorTemperature is not available anymore in JSON response

Note: This is my first Home assistant integration fix, so not sure if I missed something