### PR TITLE
Add heating curve configuration entities

### DIFF
--- a/custom_components/remeha_home/__init__.py
+++ b/custom_components/remeha_home/__init__.py
@@ -16,6 +16,7 @@ from .coordinator import RemehaHomeUpdateCoordinator
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
+    Platform.NUMBER,
     Platform.SENSOR,
     Platform.SWITCH,
 ]

--- a/custom_components/remeha_home/api.py
+++ b/custom_components/remeha_home/api.py
@@ -1,5 +1,7 @@
 """API for Remeha Home bound to Home Assistant OAuth."""
 
+from __future__ import annotations
+
 import base64
 import datetime
 import hashlib
@@ -121,6 +123,26 @@ class RemehaHomeAPI:
             "POST",
             f"/climate-zones/{climate_zone_id}/modes/fireplacemode",
             json={"fireplaceModeActive": enabled},
+        )
+        response.raise_for_status()
+
+    async def async_get_heating_curve(self, climate_zone_id: str) -> dict:
+        """Get the heating curve parameters for a climate zone."""
+        response = await self._async_api_request(
+            "GET",
+            f"/climate-zones/{climate_zone_id}/heating-curve",
+        )
+        response.raise_for_status()
+        return await response.json()
+
+    async def async_set_heating_curve(
+        self, climate_zone_id: str, slope: float, base_setpoint: float
+    ) -> None:
+        """Set the heating curve for a climate zone."""
+        response = await self._async_api_request(
+            "POST",
+            f"/climate-zones/{climate_zone_id}/heating-curve",
+            json={"slope": slope, "baseSetpoint": base_setpoint},
         )
         response.raise_for_status()
 

--- a/custom_components/remeha_home/coordinator.py
+++ b/custom_components/remeha_home/coordinator.py
@@ -1,5 +1,7 @@
 """Coordinator for fetching the Remeha Home data."""
 
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 import logging
 
@@ -34,6 +36,7 @@ class RemehaHomeUpdateCoordinator(DataUpdateCoordinator):
         self.technical_info = {}
         self.appliance_consumption_data = {}
         self.appliance_last_consumption_data_update = {}
+        self.heating_curve_data: dict[str, dict] = {}
 
     async def _async_update_data(self):
         """Fetch data from API endpoint.
@@ -166,6 +169,25 @@ class RemehaHomeUpdateCoordinator(DataUpdateCoordinator):
                     }
 
                 self.items[climate_zone_id] = climate_zone
+
+                # Fetch heating curve data once (re-fetched after writes)
+                if climate_zone_id not in self.heating_curve_data:
+                    try:
+                        self.heating_curve_data[climate_zone_id] = (
+                            await self.api.async_get_heating_curve(climate_zone_id)
+                        )
+                        _LOGGER.debug(
+                            "Requested heating curve data for climate zone %s: %s",
+                            climate_zone_id,
+                            self.heating_curve_data[climate_zone_id],
+                        )
+                    except ClientResponseError as err:
+                        _LOGGER.warning(
+                            "Failed to request heating curve data for climate zone %s: %s",
+                            climate_zone_id,
+                            err,
+                        )
+
                 self.device_info[climate_zone_id] = DeviceInfo(
                     identifiers={(DOMAIN, climate_zone_id)},
                     name=climate_zone["name"],
@@ -196,3 +218,7 @@ class RemehaHomeUpdateCoordinator(DataUpdateCoordinator):
     def get_device_info(self, item_id: str):
         """Return device info for the item with the specified id."""
         return self.device_info.get(item_id)
+
+    def get_heating_curve(self, climate_zone_id: str) -> dict | None:
+        """Return heating curve data for the specified climate zone."""
+        return self.heating_curve_data.get(climate_zone_id)

--- a/custom_components/remeha_home/number.py
+++ b/custom_components/remeha_home/number.py
@@ -1,0 +1,174 @@
+"""Platform for number integration."""
+
+from __future__ import annotations
+import logging
+
+from homeassistant.components.number import NumberDeviceClass, NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory, UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .api import RemehaHomeAPI
+from .const import DOMAIN
+from .coordinator import RemehaHomeUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the Remeha Home number entities from a config entry."""
+    api = hass.data[DOMAIN][entry.entry_id]["api"]
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+
+    entities = []
+    for appliance in coordinator.data["appliances"]:
+        for climate_zone in appliance["climateZones"]:
+            climate_zone_id = climate_zone["climateZoneId"]
+
+            # Only add heating curve entities if data was fetched successfully
+            if coordinator.get_heating_curve(climate_zone_id) is not None:
+                entities.append(
+                    RemehaHomeHeatingCurveNumber(
+                        api, coordinator, climate_zone_id, "slope"
+                    )
+                )
+                entities.append(
+                    RemehaHomeHeatingCurveNumber(
+                        api, coordinator, climate_zone_id, "base_setpoint"
+                    )
+                )
+
+    async_add_entities(entities)
+
+
+# Mapping from our parameter names to API response field names
+HEATING_CURVE_PARAMS = {
+    "slope": {
+        "value_key": "slope",
+        "min_key": "minimumSlope",
+        "max_key": "maximumSlope",
+        "step_key": "incrementSlope",
+        "name": "Heating Curve Slope",
+        "icon": "mdi:chart-line",
+        "unit": None,
+        "device_class": None,
+    },
+    "base_setpoint": {
+        "value_key": "baseSetpoint",
+        "min_key": "minimumBaseSetpoint",
+        "max_key": "maximumBaseSetpoint",
+        "step_key": "incrementBaseSetpoint",
+        "name": "Heating Curve Base Setpoint",
+        "icon": None,
+        "unit": UnitOfTemperature.CELSIUS,
+        "device_class": NumberDeviceClass.TEMPERATURE,
+    },
+}
+
+
+class RemehaHomeHeatingCurveNumber(CoordinatorEntity, NumberEntity):
+    """Representation of a heating curve number entity."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        api: RemehaHomeAPI,
+        coordinator: RemehaHomeUpdateCoordinator,
+        climate_zone_id: str,
+        parameter: str,
+    ) -> None:
+        """Create a Remeha Home heating curve number entity."""
+        super().__init__(coordinator)
+        self.api = api
+        self.climate_zone_id = climate_zone_id
+        self.parameter = parameter
+        self._param_config = HEATING_CURVE_PARAMS[parameter]
+
+        key = f"heating_curve_{parameter}"
+        self._attr_unique_id = "_".join([DOMAIN, self.climate_zone_id, key])
+        self._attr_name = self._param_config["name"]
+        self._attr_icon = self._param_config["icon"]
+        self._attr_native_unit_of_measurement = self._param_config["unit"]
+        self._attr_device_class = self._param_config["device_class"]
+
+    @property
+    def _heating_curve_data(self) -> dict | None:
+        """Return the heating curve data from the coordinator."""
+        return self.coordinator.get_heating_curve(self.climate_zone_id)
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return super().available and self._heating_curve_data is not None
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current value."""
+        data = self._heating_curve_data
+        if data is None:
+            return None
+        return data.get(self._param_config["value_key"])
+
+    @property
+    def native_min_value(self) -> float:
+        """Return the minimum value."""
+        data = self._heating_curve_data
+        if data is None:
+            return 0.0
+        return data.get(self._param_config["min_key"], 0.0)
+
+    @property
+    def native_max_value(self) -> float:
+        """Return the maximum value."""
+        data = self._heating_curve_data
+        if data is None:
+            return 100.0
+        return data.get(self._param_config["max_key"], 100.0)
+
+    @property
+    def native_step(self) -> float:
+        """Return the step value."""
+        data = self._heating_curve_data
+        if data is None:
+            return 0.1
+        return data.get(self._param_config["step_key"], 0.1)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info for this device."""
+        return self.coordinator.get_device_info(self.climate_zone_id)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the heating curve parameter value."""
+        data = self._heating_curve_data
+        if data is None:
+            return
+
+        # The API requires both slope and baseSetpoint in every POST
+        if self.parameter == "slope":
+            slope = value
+            base_setpoint = data["baseSetpoint"]
+        else:
+            slope = data["slope"]
+            base_setpoint = value
+
+        _LOGGER.debug(
+            "Setting heating curve for zone %s: slope=%s, base_setpoint=%s",
+            self.climate_zone_id,
+            slope,
+            base_setpoint,
+        )
+        await self.api.async_set_heating_curve(
+            self.climate_zone_id, slope, base_setpoint
+        )
+
+        # Invalidate cache to force re-fetch on next update
+        self.coordinator.heating_curve_data.pop(self.climate_zone_id, None)
+        await self.coordinator.async_request_refresh()


### PR DESCRIPTION
Closes #97

Expose the heating curve slope and base setpoint as number entities, allowing users to tune their weather-compensated heating curve from Home Assistant.

- `api.py` — `GET`/`POST` `/climate-zones/{id}/heating-curve`
- `coordinator.py` — fetch and cache heating curve data per climate zone
- `number.py` — `RemehaHomeHeatingCurveNumber` with min/max/step from API
- Slope is dimensionless; base setpoint uses `NumberDeviceClass.TEMPERATURE`
- Both entities use `EntityCategory.CONFIG`