### PR TITLE
Add room temperature sensor to climate zone sensor

### DIFF
--- a/custom_components/remeha_home/const.py
+++ b/custom_components/remeha_home/const.py
@@ -88,6 +88,13 @@ APPLIANCE_SENSOR_TYPES = [
 
 CLIMATE_ZONE_SENSOR_TYPES = [
     SensorEntityDescription(
+        key="roomTemperature",
+        name="Room Temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SensorEntityDescription(
         key="nextSetpoint",
         name="Next Setpoint",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,


### PR DESCRIPTION
What?
Adding a new temperature sensor that reflects the temperature of the room

Why?
New HA dashboard does not show the temperature from the available climate entity, shown in the view for the room (through related temperature sensor).