### PR TITLE
Expose activeComfortDemand and activeThermalMode as sensors

### DIFF
--- a/custom_components/remeha_home/climate.py
+++ b/custom_components/remeha_home/climate.py
@@ -55,6 +55,21 @@ PRESET_MODE_TO_PRESET_INDEX = {
 }
 
 
+def map_remeha_status_to_hvac_action(status: str | None) -> HVACAction | None:
+    """Map the raw comfort demand status to a Home Assistant HVAC action."""
+    if status is None:
+        return None
+
+    if action := REMEHA_STATUS_TO_HVAC_ACTION.get(status):
+        return action
+
+    if "Heat" in status:
+        return HVACAction.HEATING
+
+    _LOGGER.debug("Unknown comfort demand status received: %s", status)
+    return None
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -152,8 +167,7 @@ class RemehaHomeClimateEntity(CoordinatorEntity, ClimateEntity):
         if self.hvac_mode == HVACMode.OFF:
             return HVACAction.OFF
 
-        action = self._data["activeComfortDemand"]
-        return REMEHA_STATUS_TO_HVAC_ACTION.get(action)
+        return map_remeha_status_to_hvac_action(self._data.get("activeComfortDemand"))
 
     @property
     def preset_mode(self) -> str | None:

--- a/custom_components/remeha_home/const.py
+++ b/custom_components/remeha_home/const.py
@@ -22,6 +22,10 @@ APPLIANCE_SENSOR_TYPES = [
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
+        key="activeThermalMode",
+        name="Thermal Mode",
+    ),
+    SensorEntityDescription(
         key="outdoorTemperatureInformation.applianceOutdoorTemperature",
         name="Outdoor Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -87,6 +91,10 @@ APPLIANCE_SENSOR_TYPES = [
 ]
 
 CLIMATE_ZONE_SENSOR_TYPES = [
+    SensorEntityDescription(
+        key="activeComfortDemand",
+        name="Status",
+    ),
     SensorEntityDescription(
         key="nextSetpoint",
         name="Next Setpoint",


### PR DESCRIPTION
## Summary

This PR exposes two values from the dashboard API that are currently missing in Home Assistant:

- the raw climate zone `activeComfortDemand` as a sensor named `Status`
- the appliance-level `activeThermalMode` as a sensor named `Thermal Mode`

The existing binary heat status behavior remains unchanged.

## Motivation

For Baxi / BDR Thermea devices, `activeComfortDemand` is not just a boolean-like value. In real API responses I have seen at least:

- `Idle`
- `ProducingHeat`
- `RequestingHeat`

At the moment the integration only uses this value for a binary sensor and for `hvac_action`, so the raw state is not visible in HA.

Exposing the raw values is useful for monitoring boiler behavior, especially short cycling, and for distinguishing between "there is a heat request" and "the boiler is actually producing heat" when tracking burner activity.

The dashboard response also contains `activeThermalMode`, but this value is currently not exposed anywhere in the integration.

## Changes

- add a climate zone sensor for raw `activeComfortDemand`
- add an appliance sensor for `activeThermalMode`
- make `hvac_action` mapping more tolerant of additional heat-related states